### PR TITLE
Fix Race Condition on State File.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,4 @@ tag:
 
 check:
 	go test -v .
+	go test -race

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,184 @@
+package followparser
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"path"
+	"testing"
+	"time"
+)
+
+func init() {
+	log.SetOutput(io.Discard)
+}
+func TestPosFileRead(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pos_file_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tests := []struct {
+		name          string
+		content       *fPos
+		expectedPos   int64
+		expectedTime  float64
+		expectedFStat *fStat
+		expectedError bool
+	}{
+		{
+			name: "valid file",
+			content: &fPos{
+				Pos:   123,
+				Time:  float64(time.Now().Unix()),
+				Inode: 1,
+				Dev:   2,
+			},
+			expectedPos:  123,
+			expectedTime: 0.0, // Ideally time should be compared within a range
+			expectedFStat: &fStat{
+				Inode: 1,
+				Dev:   2,
+				Size:  0,
+			},
+			expectedError: false,
+		},
+		{
+			name:          "file does not exist",
+			content:       nil,
+			expectedPos:   0,
+			expectedTime:  0,
+			expectedFStat: nil,
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filename := path.Join(tmpDir, tc.name)
+			if tc.content != nil {
+				fileContent, _ := json.Marshal(tc.content)
+				os.WriteFile(filename, fileContent, 0666)
+			}
+
+			pf := newPosFile(filename)
+			pos, _, fstat, err := pf.read()
+
+			if (err != nil) != tc.expectedError {
+				t.Errorf("Expected error: %v, got: %v", tc.expectedError, err)
+			}
+
+			if pos != tc.expectedPos {
+				t.Errorf("Expected pos: %d, got: %d", tc.expectedPos, pos)
+			}
+
+			if fstat != nil && tc.expectedFStat != nil &&
+				(fstat.Inode != tc.expectedFStat.Inode || fstat.Dev != tc.expectedFStat.Dev) {
+				t.Errorf(`Expected fstat: %+v, got: %+v`, tc.expectedFStat, fstat)
+			}
+
+			// Validate duration within a reasonable time range if needed
+		})
+	}
+}
+
+func TestPosFileWrite(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pos_file_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tests := []struct {
+		name          string
+		pos           int64
+		fstat         *fStat
+		expectedError bool
+	}{
+		{
+			name: "valid write",
+			pos:  456,
+			fstat: &fStat{
+				Inode: 3,
+				Dev:   4,
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filename := path.Join(tmpDir, "pos_file.json")
+			pf := newPosFile(filename)
+			err := pf.write(tc.pos, tc.fstat)
+
+			if (err != nil) != tc.expectedError {
+				t.Errorf("Expected error: %v, got: %v", tc.expectedError, err)
+			}
+
+			if !tc.expectedError {
+				content, _ := os.ReadFile(filename)
+				readFPos := &fPos{}
+				json.Unmarshal(content, readFPos)
+
+				if readFPos.Pos != tc.pos {
+					t.Errorf("Expected pos: %d, got: %d", tc.pos, readFPos.Pos)
+				}
+
+				if readFPos.Inode != tc.fstat.Inode || readFPos.Dev != tc.fstat.Dev {
+					t.Errorf("Expected fstat: %+v, got: %+v", tc.fstat, readFPos)
+				}
+
+				// Validate time within a reasonable range if necessary
+			}
+		})
+	}
+}
+
+func TestPosFileConcurrentReadAndWrite(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := os.MkdirTemp("", "pos_file_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	filename := path.Join(tmpDir, "pos_file.json")
+	pf := newPosFile(filename)
+
+	initialPos := int64(789)
+	initialFStat := &fStat{
+		Inode: 5,
+		Dev:   6,
+	}
+	err = pf.write(initialPos, initialFStat)
+	if err != nil {
+		t.Fatalf("Failed to write initial data: %s", err)
+	}
+
+	iterations := 100
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < iterations; i++ {
+			_, _, _, err := pf.read()
+			if err != nil {
+				t.Errorf("read operation failed: %s", err)
+			}
+			time.Sleep(time.Millisecond)
+		}
+		close(done)
+	}()
+
+	for i := 0; i < iterations; i++ {
+		pos := int64(1000 + i)
+		err := pf.write(pos, initialFStat)
+		if err != nil {
+			t.Errorf("write operation failed: %s", err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	<-done
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/kazeburo/followparser
 
 go 1.13
+
+require github.com/avast/retry-go v3.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=


### PR DESCRIPTION
Hello,
I am someone who uses a large number of mackerel plugins created by kazeburo at a certain company. Recently, while using the plugins, I encountered a problem where the state JSON could not be loaded at certain times. This issue arises from read and write operations entering a race condition depending on the timing. However, since mackerel plugins are generally executed once every minute, I believe this problem occurs in cases where an operator runs it separately from the system's automatic execution or due to accumulations of retries.

In this pull request (PR), I have added retries to the reading process and changed it to sync during write operations. If this PR is accepted, I plan to make changes to the go.mod file in several other plugins and submit PRs for them as well. I would appreciate it if you could consider merging this PR.


こんにちわ。
私はとある会社で、kazeburoさんの作成したmackerelプラグインを大量に利用しているものです。
この度、プラグインを利用していて、あるタイミングでstateのjsonが読み込めない問題に遭遇しました。これはタイミングによってはreadとwriteがレースコンディションになることから発生します。
しかし、mackerelのプラグインは概ね1分に1回実行されるものですから、システムの自動実行と別にオペレーターが実行するケースやretryの積み重ねによって起こるものと考えます。

このPRでは読み取り処理にリトライを追加するのと、書き込み時にsyncするように変更しました。
このPRを取り込んでいただければいくつかのプラグインにもgo.modの変更を行ってPRする予定です。
マージを検討いただけると幸いです。

