### PR TITLE
noscan scanfile for ignore complexity warnings

### DIFF
--- a/followparser.go
+++ b/followparser.go
@@ -281,6 +281,8 @@ func (parser *Parser) CommitPosFile() error {
 	return nil
 }
 
+// Ignore code complexity warning for this function, as it is a core part of the log parsing logic.
+// BEGIN-NOSCAN
 func (parser *Parser) scanFile(f io.Reader, newest bool) (int, int64, error) {
 	scan := 0
 	read := int64(0)
@@ -376,3 +378,5 @@ func (parser *Parser) scanFile(f io.Reader, newest bool) (int, int64, error) {
 		// otherwise there was at least one newline and possibly leftover, continue reading
 	}
 }
+
+// END-NOSCAN


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `// BEGIN-NOSCAN` and `// END-NOSCAN` around `scanFile`

- Suppresses complexity warnings for core parsing logic

- Explains directive purpose via inline comment


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>followparser.go</strong><dd><code>Add complexity warning suppression for `scanFile`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

followparser.go

<ul><li>Added <code>// BEGIN-NOSCAN</code> and <code>// END-NOSCAN</code> around <code>scanFile</code><br> <li> Included explanatory comment for suppressing complexity warnings</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/55/files#diff-22336065b775ee71b4ceaf6ffb110dfa6c946724ae8e0b939180b95ed46a689d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

