### PR TITLE
test with testify

### DIFF
--- a/followparser_test.go
+++ b/followparser_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testParser struct {
@@ -140,9 +142,8 @@ func TestParse(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "log")
 	fh, err := os.Create(logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to create log file")
+
 	for i := 0; i < 2; i++ {
 		buf := bytes.NewBufferString("")
 		parser := &testParser{
@@ -160,18 +161,10 @@ func TestParse(t *testing.T) {
 			t.Error(err)
 		}
 		out := parser.Slurp().String()
-		if out != msg {
-			t.Errorf("read '%s' not match expect '%s'", out, msg)
-		}
-		if len(r) != 1 {
-			t.Errorf("result len must be 1 %v", r)
-		}
-		if r[0].Rows != 1 {
-			t.Errorf("result[0].Rows must be 1 %v", r)
-		}
-		if r[0].EndPos-r[0].StartPos != 17 {
-			t.Errorf("r[0].EndPos - r[0].StartPos must be 17 %v", r[0])
-		}
+		assert.Equal(t, msg, out, "read output does not match expected")
+		assert.Len(t, r, 1, "result len must be 1")
+		assert.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
+		assert.Equal(t, int64(17), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be 17")
 	}
 
 	time.Sleep(time.Second)
@@ -180,9 +173,8 @@ func TestParse(t *testing.T) {
 	fh.Close()
 	os.Rename(logFileName, filepath.Join(tmpdir, "log.1"))
 	fh, err = os.Create(logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to create new log file")
+
 	msg4 := fmt.Sprintf("msg msg %08d\n", 4)
 	fh.WriteString(msg4)
 	buf := bytes.NewBufferString("")
@@ -196,52 +188,38 @@ func TestParse(t *testing.T) {
 		Silent:   true,
 	}
 	r, err := fp.Parse("logPos", logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to parse log file")
+
 	out := parser.Slurp().String()
-	if out != msg3+msg4 {
-		t.Errorf("read '%s' not match expect '%s'", out, msg3+msg4)
-	}
-	if parser.duration < 1 {
-		t.Errorf("duration: %f", parser.duration)
-	}
-	if len(r) != 2 {
-		t.Errorf("result len must be 2 %v", r)
-	}
-	if r[0].Rows != 1 {
-		t.Errorf("result[0].Rows must be 1 %v", r)
-	}
-	if r[1].Rows != 1 {
-		t.Errorf("result[1].Rows must be 1 %v", r)
-	}
+	assert.Equal(t, msg3+msg4, out, "read output does not match expected")
+	assert.Equal(t, msg3+msg4, out, "read output does not match expected")
+	assert.GreaterOrEqual(t, parser.duration, 1.0, "duration must be at least 1")
+	assert.Len(t, r, 2, "result len must be 2")
+	assert.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
+	assert.Equal(t, 1, r[1].Rows, "result[1].Rows must be 1")
 
 	// --- Archive directory move test starts here ---
 	archiveDir := filepath.Join(tmpdir, "archive")
 	err = os.Mkdir(archiveDir, 0755)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to create archive directory")
+
 	// Append to the log file
 	fh.Close()
 	fh, err = os.OpenFile(logFileName, os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to open log file for appending")
+
 	msg5 := fmt.Sprintf("msg msg %08d\n", 5)
 	fh.WriteString(msg5)
 	fh.Close()
 	// Move log file to archive directory
 	archivedLog := filepath.Join(archiveDir, "log.2")
 	err = os.Rename(logFileName, archivedLog)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to move log file to archive directory")
+
 	// Create a new log file and write to it
 	fh, err = os.Create(logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to create new log file")
+
 	msg6 := fmt.Sprintf("msg msg %08d\n", 6)
 	fh.WriteString(msg6)
 	fh.Close()
@@ -257,31 +235,20 @@ func TestParse(t *testing.T) {
 		Silent:     true,
 	}
 	r, err = fp.Parse("logPos", logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to parse log file after archive move")
+
 	out = parser.Slurp().String()
-	if out != msg5+msg6 {
-		t.Errorf("archive follow read '%s' not match expect '%s'", out, msg5+msg6)
-	}
-	if len(r) != 2 {
-		t.Errorf("archive follow result len must be 2 %v", r)
-	}
-	if r[0].Rows != 1 {
-		t.Errorf("archive follow result[0].Rows must be 1 %v", r[0].Rows)
-	}
-	if r[1].Rows != 1 {
-		t.Errorf("archive follow result[1].Rows must be 1 %v", r[1].Rows)
-	}
+	assert.Equal(t, msg5+msg6, out, "archive follow read output does not match expected")
+	assert.Len(t, r, 2, "archive follow result len must be 2")
+	assert.Equal(t, 1, r[0].Rows, "archive follow result[0].Rows must be 1")
+	assert.Equal(t, 1, r[1].Rows, "archive follow result[1].Rows must be 1")
 }
 
 func TestParseWithNoCommitPosFile(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "log")
 	fh, err := os.Create(logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to create log file")
 
 	lastmsg := ""
 	var fp *Parser
@@ -300,27 +267,17 @@ func TestParseWithNoCommitPosFile(t *testing.T) {
 			NoAutoCommitPosFile: true,
 		}
 		r, err := fp.Parse("logPos", logFileName)
-		if err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, err, "failed to parse log file with NoAutoCommitPosFile")
+
 		out := parser.Slurp().String()
-		if out != lastmsg {
-			t.Errorf("read '%s' not match expect '%s'", out, lastmsg)
-		}
-		if len(r) != 1 {
-			t.Errorf("result len must be 1 %v", len(r))
-		}
-		if r[0].Rows != i+1 {
-			t.Errorf("result[0].Rows must be i+1 %v i=%d", r[0].Rows, i)
-		}
-		if r[0].EndPos-r[0].StartPos != int64(17*(i+1)) {
-			t.Errorf("r[0].EndPos - r[0].StartPos must be 17*(i+1) %v i=%d", r[0].EndPos-r[0].StartPos, i)
-		}
+		assert.Equal(t, lastmsg, out, "read output does not match expected")
+		assert.Len(t, r, 1, "result len must be 1")
+		assert.Equal(t, i+1, r[0].Rows, "result[0].Rows must be i+1")
+		assert.Equal(t, int64(17*(i+1)), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be 17*(i+1)")
 	}
 	errCommit := fp.CommitPosFile()
-	if errCommit != nil {
-		t.Error(errCommit)
-	}
+	assert.NoError(t, errCommit, "failed to commit pos file")
+
 	{
 		buf := bytes.NewBufferString("")
 		parser := &testParser{
@@ -335,23 +292,13 @@ func TestParseWithNoCommitPosFile(t *testing.T) {
 			NoAutoCommitPosFile: false,
 		}
 		r, err := fp.Parse("logPos", logFileName)
-		if err != nil {
-			t.Error(err)
-		}
-		out := parser.Slurp().String()
-		if out != msg3 {
-			t.Errorf("read '%s' not match expect '%s'", out, msg3)
-		}
-		if len(r) != 1 {
-			t.Errorf("result len must be 1 %v", len(r))
-		}
-		if r[0].Rows != 1 {
-			t.Errorf("result[0].Rows must be 1 %v", r[0].Rows)
-		}
-		if r[0].EndPos-r[0].StartPos != 17 {
-			t.Errorf("r[0].EndPos - r[0].StartPos must be 17 %v", r[0].EndPos-r[0].StartPos)
-		}
+		assert.NoError(t, err, "failed to parse log file after committing pos file")
 
+		out := parser.Slurp().String()
+		assert.Equal(t, msg3, out, "read output does not match expected")
+		assert.Len(t, r, 1, "result len must be 1")
+		assert.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
+		assert.Equal(t, int64(17), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be 17")
 	}
 }
 
@@ -361,9 +308,7 @@ func TestParseAppendAfterNoTrailingNewline(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "log")
 	fh, err := os.Create(logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to create log file")
 
 	// write a line without a trailing newline
 	previousMsg := fmt.Sprintf("msg msg %08d\n", 7)
@@ -371,9 +316,7 @@ func TestParseAppendAfterNoTrailingNewline(t *testing.T) {
 	previousMsg += fmt.Sprintf("msg msg %08d\n", 9)
 	msgNoNLBefore := "msg "
 	_, err = fh.WriteString(previousMsg + msgNoNLBefore)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to write initial content to log file")
 	fh.Sync()
 
 	// First parse: should read the existing line (even without newline)
@@ -385,28 +328,20 @@ func TestParseAppendAfterNoTrailingNewline(t *testing.T) {
 		Silent:   true,
 	}
 	r, err := fp.Parse("logPosNoNL", logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to parse log file with no trailing newline")
+
 	out := parser.Slurp().String()
-	if out != previousMsg {
-		t.Fatalf("first read '%s' not match expect '%s'", out, previousMsg)
-	}
-	if len(r) != 1 {
-		t.Fatalf("first result len must be 1 %v", r)
-	}
+	assert.Equal(t, previousMsg, out, "first read output does not match expected")
+	assert.Len(t, r, 1, "first result len must be 1")
 
 	// Append new content (with newline) to the same file
 	fh, err = os.OpenFile(logFileName, os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to open log file for appending")
+
 	msgNoNLAfter := fmt.Sprintf("msg %08d\n", 10)
 	msgAppend := fmt.Sprintf("msg msg %08d\n", 11)
 	_, err = fh.WriteString(msgNoNLAfter + msgAppend)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to write appended content to log file")
 	fh.Close()
 
 	// Second parse using same pos file name: should read only appended content
@@ -418,16 +353,11 @@ func TestParseAppendAfterNoTrailingNewline(t *testing.T) {
 		Silent:   true,
 	}
 	r2, err := fp2.Parse("logPosNoNL", logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to parse log file after appending content")
+
 	out2 := parser2.Slurp().String()
-	if out2 != msgNoNLBefore+msgNoNLAfter+msgAppend {
-		t.Fatalf("second read '%s' not match expect '%s'", out2, msgNoNLBefore+msgNoNLAfter+msgAppend)
-	}
-	if len(r2) != 1 {
-		t.Fatalf("second result len must be 1 %v", r2)
-	}
+	assert.Equal(t, msgNoNLBefore+msgNoNLAfter+msgAppend, out2, "second read output does not match expected")
+	assert.Len(t, r2, 1, "second result len must be 1")
 }
 
 // Test a single line longer than DefaultStartBufSize is read properly
@@ -435,18 +365,15 @@ func TestParseSingleLongLine(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "log")
 	fh, err := os.Create(logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to create log file")
 	// create a single long line > DefaultStartBufSize
 	longLen := DefaultStartBufSize + 100
 	data := bytes.Repeat([]byte("A"), longLen)
 	// ensure newline at end so Scanner treats it as a line
 	_, err = fh.Write(data)
-	if err != nil {
-		t.Error(err)
-	}
-	fh.WriteString("\n")
+	assert.NoError(t, err, "failed to write long line to log file")
+	_, err = fh.WriteString("\n")
+	assert.NoError(t, err, "failed to write newline to log file")
 	fh.Close()
 
 	buf := bytes.NewBufferString("")
@@ -462,18 +389,10 @@ func TestParseSingleLongLine(t *testing.T) {
 	}
 	out := parser.Slurp().String()
 	expected := string(data) + "\n"
-	if out != expected {
-		t.Fatalf("read length %d not match expect %d", len(out), len(expected))
-	}
-	if len(r) != 1 {
-		t.Fatalf("result len must be 1 %v", r)
-	}
-	if r[0].Rows != 1 {
-		t.Fatalf("result[0].Rows must be 1 %v", r[0].Rows)
-	}
-	if r[0].EndPos-r[0].StartPos != int64(len(expected)) {
-		t.Fatalf("r[0].EndPos - r[0].StartPos must be %d %v", len(expected), r[0])
-	}
+	assert.Equal(t, expected, out, "read output does not match expected")
+	assert.Len(t, r, 1, "result len must be 1")
+	assert.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
+	assert.Equal(t, int64(len(expected)), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be len(expected)")
 }
 
 // Test rotate: old (archived) file's last line has no trailing newline
@@ -482,48 +401,40 @@ func TestRotateReadOldFileWithNoTrailingNewline(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "log")
 	fh, err := os.Create(logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to create log file")
+
 	// write first line with newline and parse to set pos file
 	msg1 := fmt.Sprintf("msg msg %08d\n", 30)
-	fh.WriteString(msg1)
+	_, err = fh.WriteString(msg1)
+	assert.NoError(t, err, "failed to write first line to log file")
 	fh.Sync()
 
 	buf := bytes.NewBufferString("")
 	parser := &testParser{buf: buf}
 	fp := &Parser{WorkDir: tmpdir, Callback: parser, Silent: true}
 	r, err := fp.Parse("logPosRotateNoNL", logFileName)
-	if err != nil {
-		t.Error(err)
-	}
-	if len(r) != 1 {
-		t.Fatalf("initial parse result len must be 1 %v", r)
-	}
+	assert.NoError(t, err, "failed to parse log file after first write")
+	assert.Len(t, r, 1, "initial parse result len must be 1")
 
 	// append a line WITHOUT trailing newline
 	msg2 := fmt.Sprintf("msg msg %08d", 31)
 	fh, err = os.OpenFile(logFileName, os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		t.Error(err)
-	}
-	fh.WriteString(msg2)
+	assert.NoError(t, err, "failed to open log file for appending")
+	_, err = fh.WriteString(msg2)
+	assert.NoError(t, err, "failed to write second line to log file")
 	fh.Close()
 
 	// rotate the log (rename to archive)
 	archived := filepath.Join(tmpdir, "log.1")
 	err = os.Rename(logFileName, archived)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to rotate log file")
 
 	// create a new log file and write another line
 	fh, err = os.Create(logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to create new log file")
 	msg3 := fmt.Sprintf("msg msg %08d\n", 32)
-	fh.WriteString(msg3)
+	_, err = fh.WriteString(msg3)
+	assert.NoError(t, err, "failed to write third line to log file")
 	fh.Close()
 
 	// parse again: it should find the archived file and read msg2 (no newline)
@@ -531,34 +442,28 @@ func TestRotateReadOldFileWithNoTrailingNewline(t *testing.T) {
 	parser2 := &testParser{buf: buf2}
 	fp2 := &Parser{WorkDir: tmpdir, Callback: parser2, Silent: true}
 	r2, err := fp2.Parse("logPosRotateNoNL", logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to parse log file after rotation")
+
 	out := parser2.Slurp().String()
 	expected := msg2 + "\n" + msg3
-	if out != expected {
-		t.Fatalf("rotate read '%s' not match expect '%s'", out, expected)
-	}
-	if len(r2) != 2 {
-		t.Fatalf("rotate result len must be 2 %v", r2)
-	}
-	if r2[0].Rows != 1 || r2[1].Rows != 1 {
-		t.Fatalf("rotate rows must be 1 each %v", r2)
-	}
+	assert.Equal(t, expected, out, "rotate read output does not match expected")
+	assert.Len(t, r2, 2, "rotate result len must be 2")
+	assert.Equal(t, 1, r2[0].Rows, "rotate result[0].Rows must be 1")
+	assert.Equal(t, 1, r2[1].Rows, "rotate result[1].Rows must be 1")
 }
 
 func TestTruncated(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "truncate-log")
 	fh, err := os.Create(logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to create log file")
+
 	// write initial lines
 	var lines = 10
 	for i := 0; i < lines; i++ {
 		msg := fmt.Sprintf("msg msg %08d\n", i)
-		fh.WriteString(msg)
+		_, err = fh.WriteString(msg)
+		assert.NoError(t, err, "failed to write initial content to log file")
 	}
 	fh.Sync()
 
@@ -566,15 +471,9 @@ func TestTruncated(t *testing.T) {
 	parser := &testParser{buf: buf}
 	fp := &Parser{WorkDir: tmpdir, Callback: parser, Silent: true}
 	r, err := fp.Parse("logPosTruncateNoNL", logFileName)
-	if err != nil {
-		t.Error(err)
-	}
-	if len(r) != 1 {
-		t.Fatalf("initial parse result len must be %d %v", 1, r)
-	}
-	if r[0].Rows != lines {
-		t.Fatalf("initial parse result rows must be %d %v", lines, r[0].Rows)
-	}
+	assert.NoError(t, err, "failed to parse log file after initial write")
+	assert.Equal(t, 1, len(r), "initial parse result len must be equal to 1")
+	assert.Equal(t, lines, r[0].Rows, "initial parse result rows must be equal to lines")
 	fh.Close()
 
 	// truncate the log
@@ -588,7 +487,8 @@ func TestTruncated(t *testing.T) {
 		t.Error(err)
 	}
 	msg3 := fmt.Sprintf("msg msg %08d\n", 32)
-	fh.WriteString(msg3)
+	_, err = fh.WriteString(msg3)
+	assert.NoError(t, err, "failed to write new line to log file")
 	fh.Close()
 
 	// parse again: it should be truncated and read only the new line
@@ -596,19 +496,11 @@ func TestTruncated(t *testing.T) {
 	parser2 := &testParser{buf: buf2}
 	fp2 := &Parser{WorkDir: tmpdir, Callback: parser2, Silent: false}
 	r2, err := fp2.Parse("logPosTruncateNoNL", logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err, "failed to parse log file after truncation")
 
 	out := parser2.Slurp().String()
 	expected := msg3
-	if out != expected {
-		t.Fatalf("truncated read '%s' not match expect '%s'", out, expected)
-	}
-	if len(r2) != 1 {
-		t.Fatalf("truncated result len must be 1 %v", r2)
-	}
-	if r2[0].Rows != 1 {
-		t.Fatalf("truncated rows must be 1 each %v", r2)
-	}
+	assert.Equal(t, expected, out, "truncated read output does not match expected")
+	assert.Len(t, r2, 1, "truncated result len must be 1")
+	assert.Equal(t, 1, r2[0].Rows, "truncated result[0].Rows must be 1")
 }

--- a/followparser_test.go
+++ b/followparser_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testParser struct {
@@ -142,7 +142,7 @@ func TestParse(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "log")
 	fh, err := os.Create(logFileName)
-	assert.NoError(t, err, "failed to create log file")
+	require.NoError(t, err, "failed to create log file")
 
 	for i := 0; i < 2; i++ {
 		buf := bytes.NewBufferString("")
@@ -157,14 +157,13 @@ func TestParse(t *testing.T) {
 			Callback: parser,
 		}
 		r, err := fp.Parse("logPos", logFileName)
-		if err != nil {
-			t.Error(err)
-		}
+		require.NoError(t, err, "failed to parse log file")
+
 		out := parser.Slurp().String()
-		assert.Equal(t, msg, out, "read output does not match expected")
-		assert.Len(t, r, 1, "result len must be 1")
-		assert.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
-		assert.Equal(t, int64(17), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be 17")
+		require.Equal(t, msg, out, "read output does not match expected")
+		require.Len(t, r, 1, "result len must be 1")
+		require.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
+		require.Equal(t, int64(17), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be 17")
 	}
 
 	time.Sleep(time.Second)
@@ -173,7 +172,7 @@ func TestParse(t *testing.T) {
 	fh.Close()
 	os.Rename(logFileName, filepath.Join(tmpdir, "log.1"))
 	fh, err = os.Create(logFileName)
-	assert.NoError(t, err, "failed to create new log file")
+	require.NoError(t, err, "failed to create new log file")
 
 	msg4 := fmt.Sprintf("msg msg %08d\n", 4)
 	fh.WriteString(msg4)
@@ -188,24 +187,24 @@ func TestParse(t *testing.T) {
 		Silent:   true,
 	}
 	r, err := fp.Parse("logPos", logFileName)
-	assert.NoError(t, err, "failed to parse log file")
+	require.NoError(t, err, "failed to parse log file")
 
 	out := parser.Slurp().String()
-	assert.Equal(t, msg3+msg4, out, "read output does not match expected")
-	assert.GreaterOrEqual(t, parser.duration, 1.0, "duration must be at least 1")
-	assert.Len(t, r, 2, "result len must be 2")
-	assert.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
-	assert.Equal(t, 1, r[1].Rows, "result[1].Rows must be 1")
+	require.Equal(t, msg3+msg4, out, "read output does not match expected")
+	require.GreaterOrEqual(t, parser.duration, 1.0, "duration must be at least 1")
+	require.Len(t, r, 2, "result len must be 2")
+	require.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
+	require.Equal(t, 1, r[1].Rows, "result[1].Rows must be 1")
 
 	// --- Archive directory move test starts here ---
 	archiveDir := filepath.Join(tmpdir, "archive")
 	err = os.Mkdir(archiveDir, 0755)
-	assert.NoError(t, err, "failed to create archive directory")
+	require.NoError(t, err, "failed to create archive directory")
 
 	// Append to the log file
 	fh.Close()
 	fh, err = os.OpenFile(logFileName, os.O_APPEND|os.O_WRONLY, 0644)
-	assert.NoError(t, err, "failed to open log file for appending")
+	require.NoError(t, err, "failed to open log file for appending")
 
 	msg5 := fmt.Sprintf("msg msg %08d\n", 5)
 	fh.WriteString(msg5)
@@ -213,11 +212,11 @@ func TestParse(t *testing.T) {
 	// Move log file to archive directory
 	archivedLog := filepath.Join(archiveDir, "log.2")
 	err = os.Rename(logFileName, archivedLog)
-	assert.NoError(t, err, "failed to move log file to archive directory")
+	require.NoError(t, err, "failed to move log file to archive directory")
 
 	// Create a new log file and write to it
 	fh, err = os.Create(logFileName)
-	assert.NoError(t, err, "failed to create new log file")
+	require.NoError(t, err, "failed to create new log file")
 
 	msg6 := fmt.Sprintf("msg msg %08d\n", 6)
 	fh.WriteString(msg6)
@@ -234,20 +233,20 @@ func TestParse(t *testing.T) {
 		Silent:     true,
 	}
 	r, err = fp.Parse("logPos", logFileName)
-	assert.NoError(t, err, "failed to parse log file after archive move")
+	require.NoError(t, err, "failed to parse log file after archive move")
 
 	out = parser.Slurp().String()
-	assert.Equal(t, msg5+msg6, out, "archive follow read output does not match expected")
-	assert.Len(t, r, 2, "archive follow result len must be 2")
-	assert.Equal(t, 1, r[0].Rows, "archive follow result[0].Rows must be 1")
-	assert.Equal(t, 1, r[1].Rows, "archive follow result[1].Rows must be 1")
+	require.Equal(t, msg5+msg6, out, "archive follow read output does not match expected")
+	require.Len(t, r, 2, "archive follow result len must be 2")
+	require.Equal(t, 1, r[0].Rows, "archive follow result[0].Rows must be 1")
+	require.Equal(t, 1, r[1].Rows, "archive follow result[1].Rows must be 1")
 }
 
 func TestParseWithNoCommitPosFile(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "log")
 	fh, err := os.Create(logFileName)
-	assert.NoError(t, err, "failed to create log file")
+	require.NoError(t, err, "failed to create log file")
 
 	lastmsg := ""
 	var fp *Parser
@@ -266,16 +265,16 @@ func TestParseWithNoCommitPosFile(t *testing.T) {
 			NoAutoCommitPosFile: true,
 		}
 		r, err := fp.Parse("logPos", logFileName)
-		assert.NoError(t, err, "failed to parse log file with NoAutoCommitPosFile")
+		require.NoError(t, err, "failed to parse log file with NoAutoCommitPosFile")
 
 		out := parser.Slurp().String()
-		assert.Equal(t, lastmsg, out, "read output does not match expected")
-		assert.Len(t, r, 1, "result len must be 1")
-		assert.Equal(t, i+1, r[0].Rows, "result[0].Rows must be i+1")
-		assert.Equal(t, int64(17*(i+1)), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be 17*(i+1)")
+		require.Equal(t, lastmsg, out, "read output does not match expected")
+		require.Len(t, r, 1, "result len must be 1")
+		require.Equal(t, i+1, r[0].Rows, "result[0].Rows must be i+1")
+		require.Equal(t, int64(17*(i+1)), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be 17*(i+1)")
 	}
 	errCommit := fp.CommitPosFile()
-	assert.NoError(t, errCommit, "failed to commit pos file")
+	require.NoError(t, errCommit, "failed to commit pos file")
 
 	{
 		buf := bytes.NewBufferString("")
@@ -291,13 +290,13 @@ func TestParseWithNoCommitPosFile(t *testing.T) {
 			NoAutoCommitPosFile: false,
 		}
 		r, err := fp.Parse("logPos", logFileName)
-		assert.NoError(t, err, "failed to parse log file after committing pos file")
+		require.NoError(t, err, "failed to parse log file after committing pos file")
 
 		out := parser.Slurp().String()
-		assert.Equal(t, msg3, out, "read output does not match expected")
-		assert.Len(t, r, 1, "result len must be 1")
-		assert.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
-		assert.Equal(t, int64(17), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be 17")
+		require.Equal(t, msg3, out, "read output does not match expected")
+		require.Len(t, r, 1, "result len must be 1")
+		require.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
+		require.Equal(t, int64(17), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be 17")
 	}
 }
 
@@ -307,7 +306,7 @@ func TestParseAppendAfterNoTrailingNewline(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "log")
 	fh, err := os.Create(logFileName)
-	assert.NoError(t, err, "failed to create log file")
+	require.NoError(t, err, "failed to create log file")
 
 	// write a line without a trailing newline
 	previousMsg := fmt.Sprintf("msg msg %08d\n", 7)
@@ -315,7 +314,7 @@ func TestParseAppendAfterNoTrailingNewline(t *testing.T) {
 	previousMsg += fmt.Sprintf("msg msg %08d\n", 9)
 	msgNoNLBefore := "msg "
 	_, err = fh.WriteString(previousMsg + msgNoNLBefore)
-	assert.NoError(t, err, "failed to write initial content to log file")
+	require.NoError(t, err, "failed to write initial content to log file")
 	fh.Sync()
 
 	// First parse: should read the existing line (even without newline)
@@ -327,20 +326,20 @@ func TestParseAppendAfterNoTrailingNewline(t *testing.T) {
 		Silent:   true,
 	}
 	r, err := fp.Parse("logPosNoNL", logFileName)
-	assert.NoError(t, err, "failed to parse log file with no trailing newline")
+	require.NoError(t, err, "failed to parse log file with no trailing newline")
 
 	out := parser.Slurp().String()
-	assert.Equal(t, previousMsg, out, "first read output does not match expected")
-	assert.Len(t, r, 1, "first result len must be 1")
+	require.Equal(t, previousMsg, out, "first read output does not match expected")
+	require.Len(t, r, 1, "first result len must be 1")
 
 	// Append new content (with newline) to the same file
 	fh, err = os.OpenFile(logFileName, os.O_APPEND|os.O_WRONLY, 0644)
-	assert.NoError(t, err, "failed to open log file for appending")
+	require.NoError(t, err, "failed to open log file for appending")
 
 	msgNoNLAfter := fmt.Sprintf("msg %08d\n", 10)
 	msgAppend := fmt.Sprintf("msg msg %08d\n", 11)
 	_, err = fh.WriteString(msgNoNLAfter + msgAppend)
-	assert.NoError(t, err, "failed to write appended content to log file")
+	require.NoError(t, err, "failed to write appended content to log file")
 	fh.Close()
 
 	// Second parse using same pos file name: should read only appended content
@@ -352,11 +351,11 @@ func TestParseAppendAfterNoTrailingNewline(t *testing.T) {
 		Silent:   true,
 	}
 	r2, err := fp2.Parse("logPosNoNL", logFileName)
-	assert.NoError(t, err, "failed to parse log file after appending content")
+	require.NoError(t, err, "failed to parse log file after appending content")
 
 	out2 := parser2.Slurp().String()
-	assert.Equal(t, msgNoNLBefore+msgNoNLAfter+msgAppend, out2, "second read output does not match expected")
-	assert.Len(t, r2, 1, "second result len must be 1")
+	require.Equal(t, msgNoNLBefore+msgNoNLAfter+msgAppend, out2, "second read output does not match expected")
+	require.Len(t, r2, 1, "second result len must be 1")
 }
 
 // Test a single line longer than DefaultStartBufSize is read properly
@@ -364,15 +363,15 @@ func TestParseSingleLongLine(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "log")
 	fh, err := os.Create(logFileName)
-	assert.NoError(t, err, "failed to create log file")
+	require.NoError(t, err, "failed to create log file")
 	// create a single long line > DefaultStartBufSize
 	longLen := DefaultStartBufSize + 100
 	data := bytes.Repeat([]byte("A"), longLen)
 	// ensure newline at end so Scanner treats it as a line
 	_, err = fh.Write(data)
-	assert.NoError(t, err, "failed to write long line to log file")
+	require.NoError(t, err, "failed to write long line to log file")
 	_, err = fh.WriteString("\n")
-	assert.NoError(t, err, "failed to write newline to log file")
+	require.NoError(t, err, "failed to write newline to log file")
 	fh.Close()
 
 	buf := bytes.NewBufferString("")
@@ -383,15 +382,13 @@ func TestParseSingleLongLine(t *testing.T) {
 		Silent:   true,
 	}
 	r, err := fp.Parse("logPosLong", logFileName)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err, "failed to parse log file with single long line")
 	out := parser.Slurp().String()
 	expected := string(data) + "\n"
-	assert.Equal(t, expected, out, "read output does not match expected")
-	assert.Len(t, r, 1, "result len must be 1")
-	assert.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
-	assert.Equal(t, int64(len(expected)), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be len(expected)")
+	require.Equal(t, expected, out, "read output does not match expected")
+	require.Len(t, r, 1, "result len must be 1")
+	require.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")
+	require.Equal(t, int64(len(expected)), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be len(expected)")
 }
 
 // Test rotate: old (archived) file's last line has no trailing newline
@@ -400,40 +397,40 @@ func TestRotateReadOldFileWithNoTrailingNewline(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "log")
 	fh, err := os.Create(logFileName)
-	assert.NoError(t, err, "failed to create log file")
+	require.NoError(t, err, "failed to create log file")
 
 	// write first line with newline and parse to set pos file
 	msg1 := fmt.Sprintf("msg msg %08d\n", 30)
 	_, err = fh.WriteString(msg1)
-	assert.NoError(t, err, "failed to write first line to log file")
+	require.NoError(t, err, "failed to write first line to log file")
 	fh.Sync()
 
 	buf := bytes.NewBufferString("")
 	parser := &testParser{buf: buf}
 	fp := &Parser{WorkDir: tmpdir, Callback: parser, Silent: true}
 	r, err := fp.Parse("logPosRotateNoNL", logFileName)
-	assert.NoError(t, err, "failed to parse log file after first write")
-	assert.Len(t, r, 1, "initial parse result len must be 1")
+	require.NoError(t, err, "failed to parse log file after first write")
+	require.Len(t, r, 1, "initial parse result len must be 1")
 
 	// append a line WITHOUT trailing newline
 	msg2 := fmt.Sprintf("msg msg %08d", 31)
 	fh, err = os.OpenFile(logFileName, os.O_APPEND|os.O_WRONLY, 0644)
-	assert.NoError(t, err, "failed to open log file for appending")
+	require.NoError(t, err, "failed to open log file for appending")
 	_, err = fh.WriteString(msg2)
-	assert.NoError(t, err, "failed to write second line to log file")
+	require.NoError(t, err, "failed to write second line to log file")
 	fh.Close()
 
 	// rotate the log (rename to archive)
 	archived := filepath.Join(tmpdir, "log.1")
 	err = os.Rename(logFileName, archived)
-	assert.NoError(t, err, "failed to rotate log file")
+	require.NoError(t, err, "failed to rotate log file")
 
 	// create a new log file and write another line
 	fh, err = os.Create(logFileName)
-	assert.NoError(t, err, "failed to create new log file")
+	require.NoError(t, err, "failed to create new log file")
 	msg3 := fmt.Sprintf("msg msg %08d\n", 32)
 	_, err = fh.WriteString(msg3)
-	assert.NoError(t, err, "failed to write third line to log file")
+	require.NoError(t, err, "failed to write third line to log file")
 	fh.Close()
 
 	// parse again: it should find the archived file and read msg2 (no newline)
@@ -441,28 +438,28 @@ func TestRotateReadOldFileWithNoTrailingNewline(t *testing.T) {
 	parser2 := &testParser{buf: buf2}
 	fp2 := &Parser{WorkDir: tmpdir, Callback: parser2, Silent: true}
 	r2, err := fp2.Parse("logPosRotateNoNL", logFileName)
-	assert.NoError(t, err, "failed to parse log file after rotation")
+	require.NoError(t, err, "failed to parse log file after rotation")
 
 	out := parser2.Slurp().String()
 	expected := msg2 + "\n" + msg3
-	assert.Equal(t, expected, out, "rotate read output does not match expected")
-	assert.Len(t, r2, 2, "rotate result len must be 2")
-	assert.Equal(t, 1, r2[0].Rows, "rotate result[0].Rows must be 1")
-	assert.Equal(t, 1, r2[1].Rows, "rotate result[1].Rows must be 1")
+	require.Equal(t, expected, out, "rotate read output does not match expected")
+	require.Len(t, r2, 2, "rotate result len must be 2")
+	require.Equal(t, 1, r2[0].Rows, "rotate result[0].Rows must be 1")
+	require.Equal(t, 1, r2[1].Rows, "rotate result[1].Rows must be 1")
 }
 
 func TestTruncated(t *testing.T) {
 	tmpdir := t.TempDir()
 	logFileName := filepath.Join(tmpdir, "truncate-log")
 	fh, err := os.Create(logFileName)
-	assert.NoError(t, err, "failed to create log file")
+	require.NoError(t, err, "failed to create log file")
 
 	// write initial lines
 	var lines = 10
 	for i := 0; i < lines; i++ {
 		msg := fmt.Sprintf("msg msg %08d\n", i)
 		_, err = fh.WriteString(msg)
-		assert.NoError(t, err, "failed to write initial content to log file")
+		require.NoError(t, err, "failed to write initial content to log file")
 	}
 	fh.Sync()
 
@@ -470,24 +467,21 @@ func TestTruncated(t *testing.T) {
 	parser := &testParser{buf: buf}
 	fp := &Parser{WorkDir: tmpdir, Callback: parser, Silent: true}
 	r, err := fp.Parse("logPosTruncateNoNL", logFileName)
-	assert.NoError(t, err, "failed to parse log file after initial write")
-	assert.Equal(t, 1, len(r), "initial parse result len must be equal to 1")
-	assert.Equal(t, lines, r[0].Rows, "initial parse result rows must be equal to lines")
+	require.NoError(t, err, "failed to parse log file after initial write")
+	require.Equal(t, 1, len(r), "initial parse result len must be equal to 1")
+	require.Equal(t, lines, r[0].Rows, "initial parse result rows must be equal to lines")
 	fh.Close()
 
 	// truncate the log
-	if err = os.Truncate(logFileName, 0); err != nil {
-		t.Error(err)
-	}
-
+	err = os.Truncate(logFileName, 0)
+	require.NoError(t, err, "failed to truncate log file")
 	// reopen and write a new line
 	fh, err = os.OpenFile(logFileName, os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err, "failed to open log file for appending")
+
 	msg3 := fmt.Sprintf("msg msg %08d\n", 32)
 	_, err = fh.WriteString(msg3)
-	assert.NoError(t, err, "failed to write new line to log file")
+	require.NoError(t, err, "failed to write new line to log file")
 	fh.Close()
 
 	// parse again: it should be truncated and read only the new line
@@ -495,11 +489,11 @@ func TestTruncated(t *testing.T) {
 	parser2 := &testParser{buf: buf2}
 	fp2 := &Parser{WorkDir: tmpdir, Callback: parser2, Silent: false}
 	r2, err := fp2.Parse("logPosTruncateNoNL", logFileName)
-	assert.NoError(t, err, "failed to parse log file after truncation")
+	require.NoError(t, err, "failed to parse log file after truncation")
 
 	out := parser2.Slurp().String()
 	expected := msg3
-	assert.Equal(t, expected, out, "truncated read output does not match expected")
-	assert.Len(t, r2, 1, "truncated result len must be 1")
-	assert.Equal(t, 1, r2[0].Rows, "truncated result[0].Rows must be 1")
+	require.Equal(t, expected, out, "truncated read output does not match expected")
+	require.Len(t, r2, 1, "truncated result len must be 1")
+	require.Equal(t, 1, r2[0].Rows, "truncated result[0].Rows must be 1")
 }

--- a/followparser_test.go
+++ b/followparser_test.go
@@ -192,7 +192,6 @@ func TestParse(t *testing.T) {
 
 	out := parser.Slurp().String()
 	assert.Equal(t, msg3+msg4, out, "read output does not match expected")
-	assert.Equal(t, msg3+msg4, out, "read output does not match expected")
 	assert.GreaterOrEqual(t, parser.duration, 1.0, "duration must be at least 1")
 	assert.Len(t, r, 2, "result len must be 2")
 	assert.Equal(t, 1, r[0].Rows, "result[0].Rows must be 1")

--- a/fpos_test.go
+++ b/fpos_test.go
@@ -141,7 +141,7 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 
 	iterations := 100
 	var mu sync.Mutex
-	var ioErrs []error
+	ioErrs := make([]error, 0)
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < iterations; i++ {

--- a/fpos_test.go
+++ b/fpos_test.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -15,9 +17,7 @@ func init() {
 }
 func TestPosFileRead(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "pos_file_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err)
-	}
+	assert.NoError(t, err, "failed to create temp directory")
 	defer os.RemoveAll(tmpDir)
 
 	tests := []struct {
@@ -65,18 +65,11 @@ func TestPosFileRead(t *testing.T) {
 
 			pf := newPosFile(filename)
 			pos, _, fstat, err := pf.read()
-
-			if (err != nil) != tc.expectedError {
-				t.Errorf("Expected error: %v, got: %v", tc.expectedError, err)
-			}
-
-			if pos != tc.expectedPos {
-				t.Errorf("Expected pos: %d, got: %d", tc.expectedPos, pos)
-			}
-
-			if fstat != nil && tc.expectedFStat != nil &&
-				(fstat.Inode != tc.expectedFStat.Inode || fstat.Dev != tc.expectedFStat.Dev) {
-				t.Errorf(`Expected fstat: %+v, got: %+v`, tc.expectedFStat, fstat)
+			assert.Equal(t, tc.expectedError, err != nil, "error expectation mismatch")
+			assert.Equal(t, tc.expectedPos, pos, "pos expectation mismatch")
+			if fstat != nil && tc.expectedFStat != nil {
+				assert.Equal(t, tc.expectedFStat.Inode, fstat.Inode, "inode expectation mismatch")
+				assert.Equal(t, tc.expectedFStat.Dev, fstat.Dev, "dev expectation mismatch")
 			}
 
 			// Validate duration within a reasonable time range if needed
@@ -86,9 +79,7 @@ func TestPosFileRead(t *testing.T) {
 
 func TestPosFileWrite(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "pos_file_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err)
-	}
+	assert.NoError(t, err, "failed to create temp directory")
 	defer os.RemoveAll(tmpDir)
 
 	tests := []struct {
@@ -113,23 +104,16 @@ func TestPosFileWrite(t *testing.T) {
 			filename := path.Join(tmpDir, "pos_file.json")
 			pf := newPosFile(filename)
 			err := pf.write(tc.pos, tc.fstat)
-
-			if (err != nil) != tc.expectedError {
-				t.Errorf("Expected error: %v, got: %v", tc.expectedError, err)
-			}
+			assert.Equal(t, tc.expectedError, err != nil, "error expectation mismatch")
 
 			if !tc.expectedError {
 				content, _ := os.ReadFile(filename)
 				readFPos := &fPos{}
 				json.Unmarshal(content, readFPos)
 
-				if readFPos.Pos != tc.pos {
-					t.Errorf("Expected pos: %d, got: %d", tc.pos, readFPos.Pos)
-				}
-
-				if readFPos.Inode != tc.fstat.Inode || readFPos.Dev != tc.fstat.Dev {
-					t.Errorf("Expected fstat: %+v, got: %+v", tc.fstat, readFPos)
-				}
+				assert.Equal(t, tc.pos, readFPos.Pos, "pos expectation mismatch")
+				assert.Equal(t, tc.fstat.Inode, readFPos.Inode, "inode expectation mismatch")
+				assert.Equal(t, tc.fstat.Dev, readFPos.Dev, "dev expectation mismatch")
 
 				// Validate time within a reasonable range if necessary
 			}
@@ -140,9 +124,7 @@ func TestPosFileWrite(t *testing.T) {
 func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "pos_file_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err)
-	}
+	assert.NoError(t, err, "failed to create temp directory")
 	defer os.RemoveAll(tmpDir)
 
 	filename := path.Join(tmpDir, "pos_file.json")
@@ -154,18 +136,14 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 		Dev:   6,
 	}
 	err = pf.write(initialPos, initialFStat)
-	if err != nil {
-		t.Fatalf("Failed to write initial data: %s", err)
-	}
+	assert.NoError(t, err, "failed to write initial data")
 
 	iterations := 100
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < iterations; i++ {
 			_, _, _, err := pf.read()
-			if err != nil {
-				t.Errorf("read operation failed: %s", err)
-			}
+			assert.NoError(t, err, "read operation failed")
 			time.Sleep(time.Millisecond)
 		}
 		close(done)
@@ -174,9 +152,7 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 	for i := 0; i < iterations; i++ {
 		pos := int64(1000 + i)
 		err := pf.write(pos, initialFStat)
-		if err != nil {
-			t.Errorf("write operation failed: %s", err)
-		}
+		assert.NoError(t, err, "write operation failed")
 		time.Sleep(time.Millisecond)
 	}
 

--- a/fpos_test.go
+++ b/fpos_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -17,7 +17,7 @@ func init() {
 }
 func TestPosFileRead(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "pos_file_test")
-	assert.NoError(t, err, "failed to create temp directory")
+	require.NoError(t, err, "failed to create temp directory")
 	defer os.RemoveAll(tmpDir)
 
 	tests := []struct {
@@ -65,11 +65,11 @@ func TestPosFileRead(t *testing.T) {
 
 			pf := newPosFile(filename)
 			pos, _, fstat, err := pf.read()
-			assert.Equal(t, tc.expectedError, err != nil, "error expectation mismatch")
-			assert.Equal(t, tc.expectedPos, pos, "pos expectation mismatch")
+			require.Equal(t, tc.expectedError, err != nil, "error expectation mismatch")
+			require.Equal(t, tc.expectedPos, pos, "pos expectation mismatch")
 			if fstat != nil && tc.expectedFStat != nil {
-				assert.Equal(t, tc.expectedFStat.Inode, fstat.Inode, "inode expectation mismatch")
-				assert.Equal(t, tc.expectedFStat.Dev, fstat.Dev, "dev expectation mismatch")
+				require.Equal(t, tc.expectedFStat.Inode, fstat.Inode, "inode expectation mismatch")
+				require.Equal(t, tc.expectedFStat.Dev, fstat.Dev, "dev expectation mismatch")
 			}
 
 			// Validate duration within a reasonable time range if needed
@@ -79,7 +79,7 @@ func TestPosFileRead(t *testing.T) {
 
 func TestPosFileWrite(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "pos_file_test")
-	assert.NoError(t, err, "failed to create temp directory")
+	require.NoError(t, err, "failed to create temp directory")
 	defer os.RemoveAll(tmpDir)
 
 	tests := []struct {
@@ -104,16 +104,16 @@ func TestPosFileWrite(t *testing.T) {
 			filename := path.Join(tmpDir, "pos_file.json")
 			pf := newPosFile(filename)
 			err := pf.write(tc.pos, tc.fstat)
-			assert.Equal(t, tc.expectedError, err != nil, "error expectation mismatch")
+			require.Equal(t, tc.expectedError, err != nil, "error expectation mismatch")
 
 			if !tc.expectedError {
 				content, _ := os.ReadFile(filename)
 				readFPos := &fPos{}
 				json.Unmarshal(content, readFPos)
 
-				assert.Equal(t, tc.pos, readFPos.Pos, "pos expectation mismatch")
-				assert.Equal(t, tc.fstat.Inode, readFPos.Inode, "inode expectation mismatch")
-				assert.Equal(t, tc.fstat.Dev, readFPos.Dev, "dev expectation mismatch")
+				require.Equal(t, tc.pos, readFPos.Pos, "pos expectation mismatch")
+				require.Equal(t, tc.fstat.Inode, readFPos.Inode, "inode expectation mismatch")
+				require.Equal(t, tc.fstat.Dev, readFPos.Dev, "dev expectation mismatch")
 
 				// Validate time within a reasonable range if necessary
 			}
@@ -124,7 +124,7 @@ func TestPosFileWrite(t *testing.T) {
 func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "pos_file_test")
-	assert.NoError(t, err, "failed to create temp directory")
+	require.NoError(t, err, "failed to create temp directory")
 	defer os.RemoveAll(tmpDir)
 
 	filename := path.Join(tmpDir, "pos_file.json")
@@ -136,14 +136,14 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 		Dev:   6,
 	}
 	err = pf.write(initialPos, initialFStat)
-	assert.NoError(t, err, "failed to write initial data")
+	require.NoError(t, err, "failed to write initial data")
 
 	iterations := 100
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < iterations; i++ {
 			_, _, _, err := pf.read()
-			assert.NoError(t, err, "read operation failed")
+			require.NoError(t, err, "read operation failed")
 			time.Sleep(time.Millisecond)
 		}
 		close(done)
@@ -152,7 +152,7 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 	for i := 0; i < iterations; i++ {
 		pos := int64(1000 + i)
 		err := pf.write(pos, initialFStat)
-		assert.NoError(t, err, "write operation failed")
+		require.NoError(t, err, "write operation failed")
 		time.Sleep(time.Millisecond)
 	}
 

--- a/fpos_test.go
+++ b/fpos_test.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"os"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -140,11 +140,17 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 	require.NoError(t, err, "failed to write initial data")
 
 	iterations := 100
+	var mu sync.Mutex
+	var ioErrs []error
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < iterations; i++ {
 			_, _, _, err := pf.read()
-			assert.NoError(t, err, "read operation failed")
+			if err != nil {
+				mu.Lock()
+				ioErrs = append(ioErrs, err)
+				mu.Unlock()
+			}
 			time.Sleep(time.Millisecond)
 		}
 		close(done)
@@ -153,9 +159,14 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 	for i := 0; i < iterations; i++ {
 		pos := int64(1000 + i)
 		err := pf.write(pos, initialFStat)
-		require.NoError(t, err, "write operation failed")
+		if err != nil {
+			mu.Lock()
+			ioErrs = append(ioErrs, err)
+			mu.Unlock()
+		}
 		time.Sleep(time.Millisecond)
 	}
 
 	<-done
+	require.Empty(t, ioErrs, "expected no errors during concurrent read/write")
 }

--- a/fpos_test.go
+++ b/fpos_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -143,7 +144,7 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 	go func() {
 		for i := 0; i < iterations; i++ {
 			_, _, _, err := pf.read()
-			require.NoError(t, err, "read operation failed")
+			assert.NoError(t, err, "read operation failed")
 			time.Sleep(time.Millisecond)
 		}
 		close(done)

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,10 @@ module github.com/monitoring-forge/followparser
 go 1.25
 
 require github.com/avast/retry-go/v4 v4.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,13 @@ module github.com/monitoring-forge/followparser
 
 go 1.25
 
-require github.com/avast/retry-go/v4 v4.7.0
+require (
+	github.com/avast/retry-go/v4 v4.7.0
+	github.com/stretchr/testify v1.11.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Migrated tests to use `testify/require` assertions

- Replaced manual checks with `require.NoError` calls

- Fixed concurrent test error collection with mutex

- Added `testify` dependency to `go.mod`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  go_mod["go.mod"]
  followparser_test["followparser_test.go"]
  fpos_test["fpos_test.go"]
  go_mod -- "Add testify dependency" --> followparser_test
  followparser_test -- "Replace assertions with require" --> fpos_test
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>followparser_test.go</strong><dd><code>Migrate followparser tests to testify/require</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

followparser_test.go

<ul><li>Replaced standard <code>t.Error</code>/<code>t.Errorf</code> with <code>require.NoError</code> and <br><code>require.Equal</code><br> <li> Added import for <code>github.com/stretchr/testify/require</code><br> <li> Simplified error handling and assertion logic across multiple test <br>functions</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/56/files#diff-06e99f77167f3e605bbad2e5e2999709a3d00212381ccbb6e87127e35db9c26b">+106/-221</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fpos_test.go</strong><dd><code>Migrate fpos tests to testify/require and fix concurrency</code></dd></summary>
<hr>

fpos_test.go

<ul><li>Replaced manual assertions with <code>require</code> package functions<br> <li> Added <code>sync</code> package for mutex usage in concurrent test<br> <li> Fixed <code>TestPosFileConcurrentReadAndWrite</code> to safely collect goroutine <br>errors</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/56/files#diff-ba0e39c8dd5293b671daaae84ddefc9464c3c66ff3d465145534703428a31945">+25/-37</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Add testify dependency to go.mod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<ul><li>Added <code>github.com/stretchr/testify v1.11.1</code> as a direct dependency<br> <li> Included indirect dependencies for <code>testify</code> (<code>go-spew</code>, <code>go-difflib</code>, <br><code>yaml.v3</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/56/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

