### PR TITLE
add lint and fix some issue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,35 @@
+version: "2"
+run:
+  tests: true
+linters:
+  enable:
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - bodyclose
+    - gocognit
+    - dupl
+    - errcheck
+    - modernize
+    - errname
+    - errorlint
+    - prealloc
+
+  settings:
+    gocognit:
+      min-complexity: 15
+    dupl:
+      threshold: 100
+    modernize:
+      disable:
+        - plusbuild
+    errcheck:
+      exclude-functions:
+        - fmt.Fprintf
+        - (io.Closer).Close
+        - (*os.File).Close
+        - (*net.TCPConn).Close
+        - (*net.TCPListener).Close
+        - (*bytes.Buffer).Write
+        - (*strings.Builder).WriteString

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ check:
 
 bench:
 	go test -bench . -benchmem ./...
+
+lint:
+	golangci-lint run ./...

--- a/followparser.go
+++ b/followparser.go
@@ -68,7 +68,7 @@ func Parse(posFileName, logFile string, cb Callback) error {
 	return err
 }
 
-func (parser *Parser) verboseLog(format string, v ...interface{}) {
+func (parser *Parser) verboseLog(format string, v ...any) {
 	if !parser.Silent {
 		log.Printf(format, v...)
 	}
@@ -168,12 +168,12 @@ func (parser *Parser) Parse(posFileName, logFile string) ([]Parsed, error) {
 	parser.posFile = newPosFile(filepath.Join(parser.WorkDir, fmt.Sprintf("%s-%d", posFileName, currentUserID())))
 	lastPos, duration, lastFstat, err := parser.posFile.read()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load pos file :%v", err)
+		return nil, fmt.Errorf("failed to load pos file :%w", err)
 	}
 
 	fstat, err := fileStat(logFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get inode from log file :%v", err)
+		return nil, fmt.Errorf("failed to get inode from log file :%w", err)
 	}
 	result := make([]Parsed, 0)
 	if fstat.isNotRotated(lastFstat) {
@@ -217,7 +217,7 @@ func (parser *Parser) parseFile(logFile string, lastPos int64, newest bool) (*Pa
 
 	fstat, err := fileStat(logFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to inode of log file: %v", err)
+		return nil, fmt.Errorf("failed to get inode of log file: %w", err)
 	}
 	parser.verboseLog("Analysis start logFile:%s lastPos:%d Size:%d", logFile, lastPos, fstat.Size)
 	if lastPos == 0 && fstat.Size > parser.MaxReadSize {
@@ -232,17 +232,17 @@ func (parser *Parser) parseFile(logFile string, lastPos int64, newest bool) (*Pa
 
 	f, err := os.Open(logFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open log file :%v", err)
+		return nil, fmt.Errorf("failed to open log file :%w", err)
 	}
 	defer f.Close()
 	err = seekToPos(f, lastPos)
 	if err != nil {
-		return nil, fmt.Errorf("failed to seek log file :%v", err)
+		return nil, fmt.Errorf("failed to seek log file :%w", err)
 	}
 
 	rows, read, err := parser.scanFile(f, newest)
-	if err != nil && err != io.EOF {
-		return nil, fmt.Errorf("something wrong in parse log :%v", err)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("something wrong in parse log :%w", err)
 	}
 	curPos := lastPos + read
 
@@ -253,7 +253,7 @@ func (parser *Parser) parseFile(logFile string, lastPos int64, newest bool) (*Pa
 		if !parser.NoAutoCommitPosFile {
 			err = parser.posFile.write(curPos, fstat)
 			if err != nil {
-				return nil, fmt.Errorf("failed to update pos file :%v", err)
+				return nil, fmt.Errorf("failed to update pos file :%w", err)
 			}
 		}
 	}
@@ -276,13 +276,15 @@ func (parser *Parser) CommitPosFile() error {
 	}
 	err := parser.posFile.write(parser.lastPos, parser.lastfStat)
 	if err != nil {
-		return fmt.Errorf("failed to update pos file :%v", err)
+		return fmt.Errorf("failed to update pos file :%w", err)
 	}
 	return nil
 }
 
 // Ignore code complexity warning for this function, as it is a core part of the log parsing logic.
 // BEGIN-NOSCAN
+//
+//nolint:gocognit
 func (parser *Parser) scanFile(f io.Reader, newest bool) (int, int64, error) {
 	scan := 0
 	read := int64(0)

--- a/followparser_test.go
+++ b/followparser_test.go
@@ -3,10 +3,12 @@ package followparser
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,7 +27,7 @@ func writeTestFile(path string, line string, count int) error {
 		return err
 	}
 	defer fh.Close()
-	for i := 0; i < count; i++ {
+	for range count {
 		if _, err := fh.WriteString(line); err != nil {
 			return err
 		}
@@ -35,7 +37,7 @@ func writeTestFile(path string, line string, count int) error {
 
 func benchScannerFile(b *testing.B, fname string) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		fh, err := os.Open(fname)
 		if err != nil {
 			b.Fatal(err)
@@ -57,8 +59,7 @@ func benchScannerFile(b *testing.B, fname string) {
 
 func benchScanFile(b *testing.B, fname string) {
 	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		fh, err := os.Open(fname)
 		if err != nil {
 			b.Fatal(err)
@@ -71,7 +72,7 @@ func benchScanFile(b *testing.B, fname string) {
 			MaxReadSize:  DefaultMaxReadSize,
 		}
 		_, _, err = p.scanFile(fh, true)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			b.Fatal(err)
 		}
 		fh.Close()
@@ -144,14 +145,14 @@ func TestParse(t *testing.T) {
 	fh, err := os.Create(logFileName)
 	require.NoError(t, err, "failed to create log file")
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		buf := bytes.NewBufferString("")
 		parser := &testParser{
 			buf:      buf,
 			duration: 0,
 		}
 		msg := fmt.Sprintf("msg msg %08d\n", i)
-		fh.WriteString(msg)
+		_, _ = fh.WriteString(msg)
 		fp := &Parser{
 			WorkDir:  tmpdir,
 			Callback: parser,
@@ -168,14 +169,14 @@ func TestParse(t *testing.T) {
 
 	time.Sleep(time.Second)
 	msg3 := fmt.Sprintf("msg msg %08d\n", 3)
-	fh.WriteString(msg3)
+	_, _ = fh.WriteString(msg3)
 	fh.Close()
-	os.Rename(logFileName, filepath.Join(tmpdir, "log.1"))
+	_ = os.Rename(logFileName, filepath.Join(tmpdir, "log.1"))
 	fh, err = os.Create(logFileName)
 	require.NoError(t, err, "failed to create new log file")
 
 	msg4 := fmt.Sprintf("msg msg %08d\n", 4)
-	fh.WriteString(msg4)
+	_, _ = fh.WriteString(msg4)
 	buf := bytes.NewBufferString("")
 	parser := &testParser{
 		buf:      buf,
@@ -207,7 +208,7 @@ func TestParse(t *testing.T) {
 	require.NoError(t, err, "failed to open log file for appending")
 
 	msg5 := fmt.Sprintf("msg msg %08d\n", 5)
-	fh.WriteString(msg5)
+	_, _ = fh.WriteString(msg5)
 	fh.Close()
 	// Move log file to archive directory
 	archivedLog := filepath.Join(archiveDir, "log.2")
@@ -219,7 +220,7 @@ func TestParse(t *testing.T) {
 	require.NoError(t, err, "failed to create new log file")
 
 	msg6 := fmt.Sprintf("msg msg %08d\n", 6)
-	fh.WriteString(msg6)
+	_, _ = fh.WriteString(msg6)
 	fh.Close()
 	buf = bytes.NewBufferString("")
 	parser = &testParser{
@@ -248,17 +249,17 @@ func TestParseWithNoCommitPosFile(t *testing.T) {
 	fh, err := os.Create(logFileName)
 	require.NoError(t, err, "failed to create log file")
 
-	lastmsg := ""
+	lastmsg := strings.Builder{}
 	var fp *Parser
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		buf := bytes.NewBufferString("")
 		parser := &testParser{
 			buf:      buf,
 			duration: 0,
 		}
 		msg := fmt.Sprintf("msg msg %08d\n", i)
-		lastmsg += msg
-		fh.WriteString(msg)
+		lastmsg.WriteString(msg)
+		_, _ = fh.WriteString(msg)
 		fp = &Parser{
 			WorkDir:             tmpdir,
 			Callback:            parser,
@@ -268,7 +269,7 @@ func TestParseWithNoCommitPosFile(t *testing.T) {
 		require.NoError(t, err, "failed to parse log file with NoAutoCommitPosFile")
 
 		out := parser.Slurp().String()
-		require.Equal(t, lastmsg, out, "read output does not match expected")
+		require.Equal(t, lastmsg.String(), out, "read output does not match expected")
 		require.Len(t, r, 1, "result len must be 1")
 		require.Equal(t, i+1, r[0].Rows, "result[0].Rows must be i+1")
 		require.Equal(t, int64(17*(i+1)), r[0].EndPos-r[0].StartPos, "r[0].EndPos - r[0].StartPos must be 17*(i+1)")
@@ -283,7 +284,7 @@ func TestParseWithNoCommitPosFile(t *testing.T) {
 			duration: 0,
 		}
 		msg3 := fmt.Sprintf("msg msg %08d\n", 3)
-		fh.WriteString(msg3)
+		_, _ = fh.WriteString(msg3)
 		fp = &Parser{
 			WorkDir:             tmpdir,
 			Callback:            parser,
@@ -315,7 +316,7 @@ func TestParseAppendAfterNoTrailingNewline(t *testing.T) {
 	msgNoNLBefore := "msg "
 	_, err = fh.WriteString(previousMsg + msgNoNLBefore)
 	require.NoError(t, err, "failed to write initial content to log file")
-	fh.Sync()
+	_ = fh.Sync()
 
 	// First parse: should read the existing line (even without newline)
 	buf := bytes.NewBufferString("")
@@ -403,7 +404,7 @@ func TestRotateReadOldFileWithNoTrailingNewline(t *testing.T) {
 	msg1 := fmt.Sprintf("msg msg %08d\n", 30)
 	_, err = fh.WriteString(msg1)
 	require.NoError(t, err, "failed to write first line to log file")
-	fh.Sync()
+	_ = fh.Sync()
 
 	buf := bytes.NewBufferString("")
 	parser := &testParser{buf: buf}
@@ -456,12 +457,12 @@ func TestTruncated(t *testing.T) {
 
 	// write initial lines
 	var lines = 10
-	for i := 0; i < lines; i++ {
+	for i := range lines {
 		msg := fmt.Sprintf("msg msg %08d\n", i)
 		_, err = fh.WriteString(msg)
 		require.NoError(t, err, "failed to write initial content to log file")
 	}
-	fh.Sync()
+	_ = fh.Sync()
 
 	buf := bytes.NewBufferString("")
 	parser := &testParser{buf: buf}

--- a/fpos_test.go
+++ b/fpos_test.go
@@ -19,7 +19,9 @@ func init() {
 func TestPosFileRead(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "pos_file_test")
 	require.NoError(t, err, "failed to create temp directory")
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
 
 	tests := []struct {
 		name          string
@@ -61,7 +63,8 @@ func TestPosFileRead(t *testing.T) {
 			filename := path.Join(tmpDir, tc.name)
 			if tc.content != nil {
 				fileContent, _ := json.Marshal(tc.content)
-				os.WriteFile(filename, fileContent, 0666)
+				errWF := os.WriteFile(filename, fileContent, 0666)
+				require.NoError(t, errWF, "failed to write test content to file")
 			}
 
 			pf := newPosFile(filename)
@@ -81,7 +84,9 @@ func TestPosFileRead(t *testing.T) {
 func TestPosFileWrite(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "pos_file_test")
 	require.NoError(t, err, "failed to create temp directory")
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
 
 	tests := []struct {
 		name          string
@@ -110,7 +115,8 @@ func TestPosFileWrite(t *testing.T) {
 			if !tc.expectedError {
 				content, _ := os.ReadFile(filename)
 				readFPos := &fPos{}
-				json.Unmarshal(content, readFPos)
+				err := json.Unmarshal(content, readFPos)
+				require.NoError(t, err, "failed to unmarshal content")
 
 				require.Equal(t, tc.pos, readFPos.Pos, "pos expectation mismatch")
 				require.Equal(t, tc.fstat.Inode, readFPos.Inode, "inode expectation mismatch")
@@ -126,7 +132,9 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "pos_file_test")
 	require.NoError(t, err, "failed to create temp directory")
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
 
 	filename := path.Join(tmpDir, "pos_file.json")
 	pf := newPosFile(filename)
@@ -144,7 +152,7 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 	ioErrs := make([]error, 0)
 	done := make(chan struct{})
 	go func() {
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			_, _, _, err := pf.read()
 			if err != nil {
 				mu.Lock()
@@ -156,7 +164,7 @@ func TestPosFileConcurrentReadAndWrite(t *testing.T) {
 		close(done)
 	}()
 
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		pos := int64(1000 + i)
 		err := pf.write(pos, initialFStat)
 		if err != nil {


### PR DESCRIPTION
### **User description**
- add golangci.yml and make lint
- fix lint issues


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Wrap errors using `%w` format verb

- Modernize loops with `for range` syntax

- Configure `golangci-lint` and add Makefile target

- Enhance test error handling and assertions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["followparser.go"] --> B["Error Wrapping & Modern Syntax"]
  C["followparser_test.go"] --> D["Test Improvements"]
  E["fpos_test.go"] --> D
  F[".golangci.yml"] --> G["Linter Configuration"]
  H["Makefile"] --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>followparser.go</strong><dd><code>Modernize error handling and type aliases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

followparser.go

<ul><li>Switched <code>interface{}</code> to <code>any</code> type alias<br> <li> Updated <code>fmt.Errorf</code> to use <code>%w</code> for error wrapping<br> <li> Replaced direct <code>io.EOF</code> comparison with <code>errors.Is</code></ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/57/files#diff-22336065b775ee71b4ceaf6ffb110dfa6c946724ae8e0b939180b95ed46a689d">+12/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>followparser_test.go</strong><dd><code>Update test loops and handle return values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

followparser_test.go

<ul><li>Updated loops to <code>for range</code> syntax<br> <li> Handled <code>WriteString</code> and <code>Sync</code> return values<br> <li> Replaced string concatenation with <code>strings.Builder</code></ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/57/files#diff-06e99f77167f3e605bbad2e5e2999709a3d00212381ccbb6e87127e35db9c26b">+23/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fpos_test.go</strong><dd><code>Improve test error handling and assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fpos_test.go

<ul><li>Wrapped <code>os.RemoveAll</code> in deferred function<br> <li> Added assertions for file write and JSON unmarshal<br> <li> Updated loops to <code>for range</code> syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/57/files#diff-ba0e39c8dd5293b671daaae84ddefc9464c3c66ff3d465145534703428a31945">+15/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.golangci.yml</strong><dd><code>Add golangci-lint configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.golangci.yml

<ul><li>Added linter configuration with version 2<br> <li> Enabled multiple linters like <code>govet</code>, <code>staticcheck</code>, <code>errcheck</code><br> <li> Configured linter-specific settings and exclusions</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/57/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add lint target to Makefile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Added <code>lint</code> target to run <code>golangci-lint</code><br> <li> Ensured proper newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/57/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

