### PR TITLE
refactor: implement scanBuffer for improved file scanning logic and add benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
 
             - name: Run base benchmark
               run: |
-                  go test -bench BenchmarkScanFile -benchmem -count 5 -run '^$' . | tee base-bench.txt
+                  go test -bench BenchmarkScanFile -benchmem -count 5 -run '^$' . | tee /tmp/base-bench.txt
 
             - name: Checkout PR branch
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -39,6 +39,7 @@ jobs:
 
             - name: Run PR benchmark
               run: |
+                  cp /tmp/base-bench.txt ./base-bench.txt
                   go test -bench BenchmarkScanFile -benchmem -count 5 -run '^$' . | tee pr-bench.txt
 
             - name: Install benchstat

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,7 +42,7 @@ jobs:
                   go test -bench BenchmarkScanFile -benchmem -count 5 -run '^$' . | tee pr-bench.txt
 
             - name: Install benchstat
-              run: go install golang.org/x/perf/cmd/benchstat@latest
+              run: go install golang.org/x/perf/cmd/benchstat@82a0b07e230d76fa1b3036c383d7a98172f87334
 
             - name: Compare benchmarks
               id: compare

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,82 @@
+name: benchmark
+on:
+    pull_request:
+        types: [opened, synchronize]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    benchmark:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout base branch
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+              with:
+                  ref: ${{ github.base_ref }}
+                  fetch-depth: 0
+
+            - name: Setup Go (base)
+              uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v4
+              with:
+                  go-version-file: go.mod
+
+            - name: Run base benchmark
+              run: |
+                  go test -bench BenchmarkScanFile -benchmem -count 5 -run '^$' . | tee base-bench.txt
+
+            - name: Checkout PR branch
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  fetch-depth: 0
+
+            - name: Setup Go (PR)
+              uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v4
+              with:
+                  go-version-file: go.mod
+
+            - name: Run PR benchmark
+              run: |
+                  go test -bench BenchmarkScanFile -benchmem -count 5 -run '^$' . | tee pr-bench.txt
+
+            - name: Install benchstat
+              run: go install golang.org/x/perf/cmd/benchstat@latest
+
+            - name: Compare benchmarks
+              id: compare
+              run: |
+                  echo 'BENCHSTAT_OUTPUT<<EOF' >> "$GITHUB_OUTPUT"
+                  benchstat base-bench.txt pr-bench.txt >> "$GITHUB_OUTPUT"
+                  echo 'EOF' >> "$GITHUB_OUTPUT"
+
+            - name: Find existing benchmark comment
+              uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
+              id: find-comment
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: github-actions[bot]
+                  body-includes: "<!-- benchmark-comment -->"
+
+            - name: Post benchmark comment
+              uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
+                  edit-mode: replace
+                  body: |
+                      <!-- benchmark-comment -->
+                      ## Benchmark Comparison
+
+                      Base: `${{ github.base_ref }}`
+                      PR: `${{ github.head_ref }}`
+
+                      <details>
+                      <summary>BenchmarkScanFile results</summary>
+
+                      ```
+                      ${{ steps.compare.outputs.BENCHSTAT_OUTPUT }}
+                      ```
+
+                      </details>

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
 
             - name: Run base benchmark
               run: |
-                  go test -bench BenchmarkScanFile -benchmem -count 5 -run '^$' . | tee /tmp/base-bench.txt
+                  go test -bench BenchmarkScanFile -benchmem -count 10 -run '^$' . | tee /tmp/base-bench.txt
 
             - name: Checkout PR branch
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -40,7 +40,7 @@ jobs:
             - name: Run PR benchmark
               run: |
                   cp /tmp/base-bench.txt ./base-bench.txt
-                  go test -bench BenchmarkScanFile -benchmem -count 5 -run '^$' . | tee pr-bench.txt
+                  go test -bench BenchmarkScanFile -benchmem -count 10 -run '^$' . | tee pr-bench.txt
 
             - name: Install benchstat
               run: go install golang.org/x/perf/cmd/benchstat@82a0b07e230d76fa1b3036c383d7a98172f87334

--- a/followparser.go
+++ b/followparser.go
@@ -1,7 +1,6 @@
 package followparser
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -281,104 +280,32 @@ func (parser *Parser) CommitPosFile() error {
 	return nil
 }
 
-// Ignore code complexity warning for this function, as it is a core part of the log parsing logic.
-// BEGIN-NOSCAN
-//
-//nolint:gocognit
 func (parser *Parser) scanFile(f io.Reader, newest bool) (int, int64, error) {
-	scan := 0
-	read := int64(0)
-	buf := make([]byte, parser.StartBufSize)
-	offset := 0
+	sb := newScanBuffer(parser)
 	for {
-		nRead, err := f.Read(buf[offset:])
-		eof := false
+		nRead, eof, err := sb.readInto(f)
 		if err != nil {
-			if err == io.EOF {
-				eof = true
-			} else {
-				return scan, read, err
-			}
+			return sb.scan, sb.read, err
 		}
 
 		if nRead == 0 && eof {
-			// nothing more to read on this read call; if we have a leftover partial line
-			// in the buffer (offset > 0), process it according to the 'newest' flag.
-			if offset > 0 {
-				if !newest {
-					read += int64(offset)
-					if err := parser.Callback.Parse(buf[0:offset]); err != nil {
-						log.Printf("Failed to parse log :%v", err)
-					}
-					scan++
-				}
-			}
-			return scan, read, io.EOF
+			sb.flushTrailingLine(newest)
+			return sb.scan, sb.read, io.EOF
 		}
 
-		n := nRead + offset
-
-		// scan lines within buf[0:n]
-		k := 0
-		for {
-			idx := bytes.IndexByte(buf[k:n], '\n')
-			if idx < 0 {
-				break
-			}
-			// found newline at k+idx
-			read += int64(idx + 1)
-			if err := parser.Callback.Parse(buf[k : k+idx]); err != nil {
-				log.Printf("Failed to parse log :%v", err)
-			}
-			scan++
-			k += idx + 1
-		}
-
-		if k < n {
-			// remaining partial line in buffer
-			// move it to the head for next read
-			copy(buf[0:], buf[k:n])
-			offset = n - k
-		} else {
-			offset = 0
-		}
+		n := nRead + sb.offset
+		sb.processChunk(n)
 
 		if eof {
-			// if file ended and there is a remaining partial line
-			if offset > 0 {
-				if !newest {
-					// for rotated/old files, parse the final partial line
-					read += int64(offset)
-					if err := parser.Callback.Parse(buf[0:offset]); err != nil {
-						log.Printf("Failed to parse log :%v", err)
-					}
-					scan++
-				}
-			}
-			return scan, read, io.EOF
+			sb.flushTrailingLine(newest)
+			return sb.scan, sb.read, io.EOF
 		}
 
-		// current buffer is full
-		// If offset == n, then no newlines were found in the current buffer,
-		// so the entire buffer is a partial line. Continue reading or expand the buffer.
-		if offset == n {
-			// buffer is maxsize
-			if n == parser.MaxBufSize {
-				return scan, read, ErrTokenTooLong
+		// If the buffer is full with no newlines, expand and continue reading.
+		if sb.offset == n {
+			if expandErr := sb.expand(n); expandErr != nil {
+				return sb.scan, sb.read, expandErr
 			}
-			if n == len(buf) {
-				// expand buffer
-				newSize := len(buf) * 2
-				newSize = min(newSize, parser.MaxBufSize)
-				newBuf := make([]byte, newSize)
-				copy(newBuf, buf)
-				buf = newBuf
-			}
-			// continue reading into buffer at offset
-			continue
 		}
-		// otherwise there was at least one newline and possibly leftover, continue reading
 	}
 }
-
-// END-NOSCAN

--- a/followparser.go
+++ b/followparser.go
@@ -86,6 +86,9 @@ func (parser *Parser) parseInit(logFile string) {
 	if parser.MaxReadSize == 0 {
 		parser.MaxReadSize = DefaultMaxReadSize
 	}
+	if parser.StartBufSize > parser.MaxBufSize {
+		parser.StartBufSize = parser.MaxBufSize
+	}
 	if parser.Callback == nil {
 		parser.Callback = &dummyParser{}
 	}

--- a/scanbuffer.go
+++ b/scanbuffer.go
@@ -1,0 +1,103 @@
+package followparser
+
+import (
+	"bytes"
+	"io"
+	"log"
+)
+
+// scanBuffer holds the mutable state used while scanning a single file.
+type scanBuffer struct {
+	parser *Parser
+	buf    []byte
+	scan   int
+	read   int64
+	offset int
+}
+
+// newScanBuffer creates a scanBuffer initialized with the parser's StartBufSize.
+func newScanBuffer(parser *Parser) *scanBuffer {
+	return &scanBuffer{
+		parser: parser,
+		buf:    make([]byte, parser.StartBufSize),
+	}
+}
+
+// parseLine parses a single line and updates counters.
+func (s *scanBuffer) parseLine(line []byte) {
+	if err := s.parser.Callback.Parse(line); err != nil {
+		log.Printf("Failed to parse log :%v", err)
+	}
+	s.scan++
+}
+
+// flushTrailingLine handles a partial line remaining at the end of a file.
+func (s *scanBuffer) flushTrailingLine(newest bool) {
+	if s.offset == 0 || newest {
+		return
+	}
+	s.read += int64(s.offset)
+	s.parseLine(s.buf[0:s.offset])
+}
+
+// scanNewlines parses all complete lines in buf[0:n] and returns the index
+// after the last newline that was consumed (or 0 if none were found).
+func (s *scanBuffer) scanNewlines(n int) int {
+	k := 0
+	for {
+		idx := bytes.IndexByte(s.buf[k:n], '\n')
+		if idx < 0 {
+			break
+		}
+		// found newline at k+idx
+		s.read += int64(idx + 1)
+		s.parseLine(s.buf[k : k+idx])
+		k += idx + 1
+	}
+	return k
+}
+
+// compact moves any remaining partial line to the head of the buffer.
+func (s *scanBuffer) compact(n, k int) {
+	if k < n {
+		copy(s.buf[0:], s.buf[k:n])
+		s.offset = n - k
+	} else {
+		s.offset = 0
+	}
+}
+
+// expand grows the buffer when it is full and contains no newlines.
+func (s *scanBuffer) expand(n int) error {
+	if n == s.parser.MaxBufSize {
+		return ErrTokenTooLong
+	}
+	if n == len(s.buf) {
+		newSize := len(s.buf) * 2
+		newSize = min(newSize, s.parser.MaxBufSize)
+		newBuf := make([]byte, newSize)
+		copy(newBuf, s.buf)
+		s.buf = newBuf
+	}
+	return nil
+}
+
+// readInto performs a single read into the buffer and returns the number of
+// bytes read and whether EOF was reached. Non-EOF errors are returned as-is.
+func (s *scanBuffer) readInto(f io.Reader) (int, bool, error) {
+	nRead, err := f.Read(s.buf[s.offset:])
+	if err == nil {
+		return nRead, false, nil
+	}
+	if err == io.EOF {
+		return nRead, true, nil
+	}
+	return nRead, false, err
+}
+
+// processChunk parses all complete lines from the current buffer contents and
+// compacts any remaining partial line to the head of the buffer.
+func (s *scanBuffer) processChunk(n int) {
+	k := s.scanNewlines(n)
+	s.compact(n, k)
+}

--- a/scanbuffer_test.go
+++ b/scanbuffer_test.go
@@ -1,0 +1,243 @@
+package followparser
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// collectingCallback is a test Callback that records every parsed line.
+type collectingCallback struct {
+	lines []string
+}
+
+func (c *collectingCallback) Parse(b []byte) error {
+	c.lines = append(c.lines, string(b))
+	return nil
+}
+
+func (c *collectingCallback) Finish(float64) {}
+
+// failingCallback returns a configured error for every parse.
+type failingCallback struct {
+	err error
+}
+
+func (f *failingCallback) Parse([]byte) error { return f.err }
+func (f *failingCallback) Finish(float64)     {}
+
+func newTestParser() (*Parser, *collectingCallback) {
+	cb := &collectingCallback{}
+	p := &Parser{
+		Callback:     cb,
+		StartBufSize: 16,
+		MaxBufSize:   256,
+	}
+	return p, cb
+}
+
+func TestScanBufferProcessChunk(t *testing.T) {
+	parser, cb := newTestParser()
+	sb := newScanBuffer(parser)
+	sb.buf = make([]byte, 32)
+
+	copy(sb.buf, "line1\nline2\nline3")
+	sb.processChunk(17)
+
+	require.Equal(t, []string{"line1", "line2"}, cb.lines)
+	require.Equal(t, 2, sb.scan)
+	require.Equal(t, int64(12), sb.read)
+	require.Equal(t, 5, sb.offset)
+	require.Equal(t, "line3", string(sb.buf[0:sb.offset]))
+}
+
+func TestScanBufferFlushTrailingLine(t *testing.T) {
+	parser, cb := newTestParser()
+	sb := newScanBuffer(parser)
+	sb.buf = make([]byte, 32)
+
+	copy(sb.buf, "no-newline")
+	sb.offset = 10
+	sb.flushTrailingLine(false)
+
+	require.Equal(t, []string{"no-newline"}, cb.lines)
+	require.Equal(t, int64(10), sb.read)
+}
+
+func TestScanBufferFlushTrailingLineNewest(t *testing.T) {
+	parser, cb := newTestParser()
+	sb := newScanBuffer(parser)
+	sb.buf = make([]byte, 32)
+
+	copy(sb.buf, "no-newline")
+	sb.offset = 10
+	sb.flushTrailingLine(true)
+
+	require.Empty(t, cb.lines)
+	require.Equal(t, int64(0), sb.read)
+}
+
+func TestScanBufferReadInto(t *testing.T) {
+	parser, _ := newTestParser()
+	sb := newScanBuffer(parser)
+	sb.buf = make([]byte, 32)
+
+	r := strings.NewReader("hello")
+	n, eof, err := sb.readInto(r)
+	require.NoError(t, err)
+	require.False(t, eof)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", string(sb.buf[0:5]))
+}
+
+func TestScanBufferReadIntoWithPrefix(t *testing.T) {
+	parser, _ := newTestParser()
+	sb := newScanBuffer(parser)
+	sb.buf = make([]byte, 32)
+
+	copy(sb.buf, "pre-")
+	sb.offset = 4
+
+	r := strings.NewReader("fix")
+	n, eof, err := sb.readInto(r)
+	require.NoError(t, err)
+	require.False(t, eof)
+	require.Equal(t, 3, n)
+	require.Equal(t, "pre-fix", string(sb.buf[0:7]))
+}
+
+func TestScanBufferReadIntoError(t *testing.T) {
+	parser, _ := newTestParser()
+	sb := newScanBuffer(parser)
+	sb.buf = make([]byte, 32)
+
+	errReader := &errorReader{err: io.ErrUnexpectedEOF}
+	_, _, err := sb.readInto(errReader)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+type errorReader struct {
+	err error
+}
+
+func (e *errorReader) Read([]byte) (int, error) {
+	return 0, e.err
+}
+
+func TestScanBufferExpand(t *testing.T) {
+	parser, _ := newTestParser()
+	sb := newScanBuffer(parser)
+
+	err := sb.expand(16)
+	require.NoError(t, err)
+	require.Equal(t, 32, len(sb.buf))
+}
+
+func TestScanBufferExpandMax(t *testing.T) {
+	parser, _ := newTestParser()
+	parser.MaxBufSize = 16
+	sb := newScanBuffer(parser)
+
+	err := sb.expand(16)
+	require.ErrorIs(t, err, ErrTokenTooLong)
+}
+
+func TestScanBufferExpandCappedByMax(t *testing.T) {
+	parser, _ := newTestParser()
+	parser.StartBufSize = 16
+	parser.MaxBufSize = 24
+	sb := newScanBuffer(parser)
+
+	err := sb.expand(16)
+	require.NoError(t, err)
+	require.Equal(t, 24, len(sb.buf))
+}
+
+func TestScanBufferCompactPartial(t *testing.T) {
+	parser, _ := newTestParser()
+	sb := newScanBuffer(parser)
+	sb.buf = make([]byte, 32)
+
+	copy(sb.buf, "abc123")
+	sb.compact(6, 3)
+
+	require.Equal(t, 3, sb.offset)
+	require.Equal(t, "123", string(sb.buf[0:3]))
+}
+
+func TestScanBufferCompactAllConsumed(t *testing.T) {
+	parser, _ := newTestParser()
+	sb := newScanBuffer(parser)
+	sb.buf = make([]byte, 32)
+
+	copy(sb.buf, "abc")
+	sb.offset = 3
+	sb.compact(3, 3)
+
+	require.Equal(t, 0, sb.offset)
+}
+
+func TestScanBufferScanNewlinesWithMultipleLines(t *testing.T) {
+	parser, cb := newTestParser()
+	sb := newScanBuffer(parser)
+	sb.buf = make([]byte, 32)
+
+	copy(sb.buf, "a\nb\nc")
+	k := sb.scanNewlines(5)
+
+	require.Equal(t, 4, k)
+	require.Equal(t, []string{"a", "b"}, cb.lines)
+	require.Equal(t, int64(4), sb.read)
+}
+
+func TestScanBufferParseLineError(t *testing.T) {
+	cb := &failingCallback{err: io.ErrClosedPipe}
+	parser := &Parser{
+		Callback:     cb,
+		StartBufSize: 16,
+		MaxBufSize:   256,
+	}
+	sb := newScanBuffer(parser)
+
+	// parseLine logs but does not return the error, so just verify it does not panic
+	// and updates the scan counter.
+	sb.parseLine([]byte("x"))
+	require.Equal(t, 1, sb.scan)
+}
+
+func TestScanBufferScanFile(t *testing.T) {
+	cb := &collectingCallback{}
+	p := &Parser{
+		Callback:     cb,
+		StartBufSize: DefaultStartBufSize,
+		MaxBufSize:   DefaultMaxBufSize,
+		MaxReadSize:  DefaultMaxReadSize,
+	}
+
+	r := bytes.NewReader([]byte("one\ntwo\nthree"))
+	rows, read, err := p.scanFile(r, false)
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, 3, rows)
+	require.Equal(t, int64(13), read)
+	require.Equal(t, []string{"one", "two", "three"}, cb.lines)
+}
+
+func TestScanBufferScanFileLongLine(t *testing.T) {
+	cb := &collectingCallback{}
+	p := &Parser{
+		Callback:     cb,
+		StartBufSize: 16,
+		MaxBufSize:   256,
+	}
+
+	longLine := strings.Repeat("A", 100) + "\n"
+	r := strings.NewReader(longLine)
+	rows, read, err := p.scanFile(r, false)
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, 1, rows)
+	require.Equal(t, int64(101), read)
+	require.Equal(t, []string{strings.TrimSuffix(longLine, "\n")}, cb.lines)
+}


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Refactors file scanning into reusable `scanBuffer`

- Preserves line parsing, EOF, and buffer growth

- Prevents `StartBufSize` from exceeding `MaxBufSize`

- Adds scanner tests and automated benchmark comparisons


___

### Diagram Walkthrough


```mermaid
flowchart LR
  scanFile["Parser.scanFile"] --> scanBuffer["scanBuffer state"]
  scanBuffer --> lineProcessing["Line parsing and buffering"]
  lineProcessing --> scanTests["Unit and integration tests"]
  benchmarkWorkflow["Benchmark workflow"] --> benchmarkComparison["Base versus PR comparison"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>followparser.go</strong><dd><code>Delegate file scanning to reusable buffer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

followparser.go

<ul><li>Replaces inline scanning logic with <code>scanBuffer</code><br> <li> Preserves partial-line and EOF handling<br> <li> Returns buffer-managed scan and read counters<br> <li> Caps <code>StartBufSize</code> at <code>MaxBufSize</code></ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/61/files#diff-22336065b775ee71b4ceaf6ffb110dfa6c946724ae8e0b939180b95ed46a689d">+16/-86</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scanbuffer.go</strong><dd><code>Add reusable buffered scanning implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scanbuffer.go

<ul><li>Adds stateful buffer management for file scanning<br> <li> Handles newline detection and partial-line compaction<br> <li> Supports bounded buffer expansion and token errors<br> <li> Logs callback parsing failures consistently</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/61/files#diff-8b7a36301bc88b7604767a36521bdf9af1f7ce2dda9e4687d48bc0f436ba9279">+103/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scanbuffer_test.go</strong><dd><code>Add comprehensive scan buffer test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scanbuffer_test.go

<ul><li>Tests chunk processing and trailing-line behavior<br> <li> Covers reads, errors, expansion, and compaction<br> <li> Verifies newline scanning and callback failures<br> <li> Adds end-to-end short and long line tests</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/61/files#diff-0c83d5bd581ca50ddaa36a0c2cb35b06bdb29ad0df5fdb5a07db063a99c33787">+243/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>benchmark.yml</strong><dd><code>Automate pull request benchmark comparisons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/benchmark.yml

<ul><li>Adds pull request benchmark comparison workflow<br> <li> Runs base and PR benchmarks ten times<br> <li> Pins the <code>benchstat</code> installation version<br> <li> Posts results to pull request comments</ul>


</details>


  </td>
  <td><a href="https://github.com/monitoring-forge/followparser/pull/61/files#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0">+83/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

